### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENT instructions for rust-prac
+
+このリポジトリでは、コードを変更する際は必ず以下のコマンドでテストとリンターを実行してください。
+
+```
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+```
+
+各サブプロジェクト（例: `hello-koma`、`actix-gcd` など）に `Cargo.toml` がある場合は、そのディレクトリで上記コマンドを実行します。ドキュメントやコメントのみの変更の場合は、テストやリンターの実行は不要です。
+
+コードを変更する際は必ず対応するテストコードも追加し、TDD を意識して実装してください。責務の分離を心掛け、1 ファイルに多くのロジックを詰め込みすぎないよう注意します。設計は Clean Architecture や DDD を参考にしますが、厳密な適用は必須ではありません。
+
+また、すべての回答および PR メッセージは日本語で記述してください。


### PR DESCRIPTION
## Summary
- AGENTS.md を追加し、テストとリンター実行の指示を記載

## Testing
- `cargo fmt --all -- --check` (skipped: documentation only)


------
https://chatgpt.com/codex/tasks/task_e_684705ad88648330ad9f391bde59c04b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - コントリビューター向けのガイドラインを記載した新しいドキュメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->