### PR TITLE
Add wasm calculator with display error handling

### DIFF
--- a/wasm-calculator/main.js
+++ b/wasm-calculator/main.js
@@ -1,0 +1,20 @@
+function evaluateExpression(expr) {
+  // Evaluate arithmetic expression safely
+  return Function('return (' + expr + ')')();
+}
+
+function setupCalculator(display, enterButton) {
+  enterButton.addEventListener('click', () => {
+    if (!display.value.trim()) return;
+    try {
+      display.value = String(evaluateExpression(display.value));
+    } catch (e) {
+      display.value = 'エラー';
+      setTimeout(() => {
+        display.value = '';
+      }, 2000);
+    }
+  });
+}
+
+module.exports = { evaluateExpression, setupCalculator };

--- a/wasm-calculator/main.js
+++ b/wasm-calculator/main.js
@@ -1,6 +1,11 @@
 function evaluateExpression(expr) {
-  // Evaluate arithmetic expression safely
-  return Function('return (' + expr + ')')();
+  // NOTE: This uses the Function constructor, which is unsafe for untrusted input.
+  // We first check that the expression only contains digits, operators and parentheses
+  // to reduce risk, but a proper math parser should be used in real applications.
+  if (!/^[0-9+\-*/().\s]+$/.test(expr)) {
+    throw new Error('invalid expression');
+  }
+  return Function('"use strict"; return (' + expr + ')')();
 }
 
 function setupCalculator(display, enterButton) {

--- a/wasm-calculator/test_main.js
+++ b/wasm-calculator/test_main.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+const { setupCalculator } = require('./main');
+
+function createButton() {
+  return {
+    listeners: {},
+    addEventListener(event, cb) {
+      this.listeners[event] = cb;
+    }
+  };
+}
+
+async function testSuccess() {
+  const display = { value: '1+2' };
+  const button = createButton();
+  setupCalculator(display, button);
+  button.listeners.click();
+  assert.strictEqual(display.value, '3');
+}
+
+async function testError() {
+  const display = { value: '1a' };
+  const button = createButton();
+  setupCalculator(display, button);
+  button.listeners.click();
+  assert.strictEqual(display.value, 'エラー');
+  await new Promise(r => setTimeout(r, 2100));
+  assert.strictEqual(display.value, '');
+}
+
+async function testEmptyInput() {
+  const display = { value: '   ' };
+  const button = createButton();
+  setupCalculator(display, button);
+  button.listeners.click();
+  assert.strictEqual(display.value, '   ');
+}
+
+(async () => {
+  await testSuccess();
+  await testError();
+  await testEmptyInput();
+  console.log('All tests passed');
+})();

--- a/wasm-calculator/test_main.js
+++ b/wasm-calculator/test_main.js
@@ -28,6 +28,16 @@ async function testError() {
   assert.strictEqual(display.value, '');
 }
 
+async function testInjection() {
+  const display = { value: '1+process.exit()' };
+  const button = createButton();
+  setupCalculator(display, button);
+  button.listeners.click();
+  assert.strictEqual(display.value, 'エラー');
+  await new Promise(r => setTimeout(r, 2100));
+  assert.strictEqual(display.value, '');
+}
+
 async function testEmptyInput() {
   const display = { value: '   ' };
   const button = createButton();
@@ -39,6 +49,7 @@ async function testEmptyInput() {
 (async () => {
   await testSuccess();
   await testError();
+  await testInjection();
   await testEmptyInput();
   console.log('All tests passed');
 })();


### PR DESCRIPTION
## Summary
- add simple wasm-calculator example
- show `エラー` in display for invalid expressions and clear after 2 seconds
- ignore empty input on enter click
- add tests for calculator behavior

## Testing
- `node wasm-calculator/test_main.js`
- `cargo test --manifest-path actix-gcd/Cargo.toml` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684705da14148330b5e987af059bd0e5