### PR TITLE
Add decimal parser with error checks

### DIFF
--- a/hello-koma/src/main.rs
+++ b/hello-koma/src/main.rs
@@ -1,6 +1,8 @@
 use std::env;
 use std::str::FromStr;
 
+mod parser;
+
 fn main() {
     println!("Hello, world!");
     // Vec is a growable array

--- a/hello-koma/src/parser.rs
+++ b/hello-koma/src/parser.rs
@@ -1,0 +1,55 @@
+pub fn parse_decimal(input: &str) -> Result<f64, &'static str> {
+    if input.is_empty() {
+        return Err("empty input");
+    }
+    let mut has_dot = false;
+    for c in input.chars() {
+        if c == '.' {
+            if has_dot {
+                return Err("multiple dots");
+            }
+            has_dot = true;
+        } else if !c.is_ascii_digit() {
+            return Err("invalid character");
+        }
+    }
+    if input == "." {
+        return Err("invalid number");
+    }
+    input.parse::<f64>().map_err(|_| "parse error")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_decimal;
+
+    #[test]
+    fn parse_integer() {
+        assert_eq!(parse_decimal("42").unwrap(), 42.0);
+    }
+
+    #[test]
+    fn parse_float() {
+        assert_eq!(parse_decimal("3.14").unwrap(), 3.14);
+    }
+
+    #[test]
+    fn error_multiple_dots() {
+        assert!(parse_decimal("1.2.3").is_err());
+    }
+
+    #[test]
+    fn error_empty() {
+        assert!(parse_decimal("").is_err());
+    }
+
+    #[test]
+    fn error_only_dot() {
+        assert!(parse_decimal(".").is_err());
+    }
+
+    #[test]
+    fn error_invalid_char() {
+        assert!(parse_decimal("1a2").is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- 数値文字列を解析する`parse_decimal`関数を追加
- `has_dot`フラグを用いて小数点は一度だけ許可
- 空文字や`.`のみの場合はエラーを返す
- 上記機能を検証するテストを追加
- `main.rs`にモジュールを登録

## Testing
- `cargo test --quiet` in `hello-koma`
- `cargo test --quiet` in `actix-gcd` *(failed: failed to download from crates.io)*
- `cargo clippy -- -D warnings` *(failed: clippy not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684705d56b44833087ba2e7412bd4b1f